### PR TITLE
Adds a way to interpolate urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ If you need to audit just one URL, use the `url` option:
 url: https://example.com/
 ```
 
+URLs support interpolation of process env vars, so you can write URLs like:
+
+```yml
+- name: Run Lighthouse and test budgets
+    uses: treosh/lighthouse-ci-action@v1
+    with:
+      urls: |
+        https://pr-$PR_NUMBER.staging-example.com/
+        https://pr-$PR_NUMBER.staging-example.com/blog
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+```
+
 ### `budgetPath`
 
 Use a performance budget to keep your page size in check. `Lighthouse CI Action` will fail the build if one of the URLs exceed the budget.
@@ -142,7 +155,7 @@ budgetPath: .github/lighthouse/budget.json
 
 ### `configPath`
 
-Set a path to a custom [Lighthouse config](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md) for a full control of Lighthouse enviroment.
+Set a path to a custom [Lighthouse config](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md) for a full control of Lighthouse environment.
 
 ```yml
 configPath: ./desktop-config.js

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,9 @@ const { readFileSync } = require('fs')
 // audit urls with Lighthouse
 
 async function main() {
-  const urls = getUrls()
+  const unprocessedURLs = getUrls()
+  const urls = interpolateProcessIntoURLs(unprocessedURLs)
+
   const resultsPath = join(process.cwd(), 'results')
   const flags = {
     output: 'html',
@@ -103,6 +105,24 @@ function getUrls() {
   if (url) return [url]
   const urls = core.getInput('urls')
   return urls.split('\n').map(url => url.trim())
+}
+
+/**
+ * Takes a set of URL strings and interpolates
+ * any declared ENV vars into them
+ * @param {string[]} urls
+ * @return {string[]}
+ */
+function interpolateProcessIntoURLs(urls) {
+  return urls.map(url => {
+    if(!url.includes("$")) return url;
+    Object.keys(process.env).forEach(key => {
+      if(url.includes(`${key}`)) {
+        url = url.replace(`$${key}`, `${process.env[key]}`)
+      }
+    })
+    return url
+  })
 }
 
 /** @return {object} */

--- a/src/index.js
+++ b/src/index.js
@@ -115,9 +115,9 @@ function getUrls() {
  */
 function interpolateProcessIntoURLs(urls) {
   return urls.map(url => {
-    if(!url.includes("$")) return url;
+    if (!url.includes('$')) return url
     Object.keys(process.env).forEach(key => {
-      if(url.includes(`${key}`)) {
+      if (url.includes(`${key}`)) {
         url = url.replace(`$${key}`, `${process.env[key]}`)
       }
     })


### PR DESCRIPTION
Example: https://codesandbox.io/s/priceless-lake-d48pn

This allows for implicit interpolation of env vars in a way consistent with the shell - it's pretty defensive about making changes to string, so perf shouldn't be an issue 