### PR TITLE
Fix misplaced env config in workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ URLs support interpolation of process env vars so that you can write URLs like:
       https://pr-$PR_NUMBER.staging-example.com/blog
     budgetPath: ./budgets.json
     temporaryPublicStorage: true
-    env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
+  env:
+    PR_NUMBER: ${{ github.event.pull_request.number }}
 ```
 
 [⚙️ See this workflow in use](https://github.com/treosh/lighthouse-ci-action/actions?workflow=LHCI-urls-interpolation)


### PR DESCRIPTION
In the workflow example showing interpolation of process env variables, the `env` config is placed inside `with`. However, this is invalid and will cause the following error when the workflow runs:

```
### ERRORED 16:17:51Z

- Your workflow file was invalid: The pipeline is not valid. .github/workflows/lighthouse.yml (Line: 30, Col: 13): A mapping was not expected
```

This PR places the the `env` config in the same hierarchy as the `with` config, where it should be.