### PR TITLE
Allow setting URLs in from lighthouse config JSON 

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -32,8 +32,8 @@ function getArgs() {
     // Check if we have a static-dist-dir
     if (rcCollect) {
           
-      if ('urls' in rcFileObj.ci.collect) {
-        urls =  rcFileObj.ci.collect.urls
+      if ('url' in rcFileObj.ci.collect) {
+        urls =  rcFileObj.ci.collect.url
       }
 
       if ('staticDistDir' in rcFileObj.ci.collect) {

--- a/src/input.js
+++ b/src/input.js
@@ -14,6 +14,8 @@ function getArgs() {
   let rcCollect = false
   let rcAssert = false
   let staticDistDir = undefined
+  let urls = undefined
+
   // Inspect lighthouserc file for malformations
   const configPath = getArg('configPath')
   if (configPath) {
@@ -29,6 +31,11 @@ function getArgs() {
 
     // Check if we have a static-dist-dir
     if (rcCollect) {
+          
+      if ('urls' in rcFileObj.ci.collect) {
+        urls =  rcFileObj.ci.collect.urls
+      }
+
       if ('staticDistDir' in rcFileObj.ci.collect) {
         staticDistDir = rcFileObj.ci.collect.staticDistDir
       }
@@ -36,7 +43,7 @@ function getArgs() {
   }
 
   // Get and interpolate URLs
-  const urls = interpolateProcessIntoURLs(getList('urls'))
+  urls = urls || interpolateProcessIntoURLs(getList('urls'))
 
   // Make sure we have either urls or a static-dist-dir
   if (!urls && !staticDistDir) {


### PR DESCRIPTION
[lighthouse-ci has the option](https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/cli.md#collect) `url` in `collect` which allows setting your own URLs. From [their samples](https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/configuration.md#non-nodejs-server):

```json
{
  "ci": {
    "collect": {
      "startServerCommand": "rails server -e production",
      "url": [
        "http://localhost:3000/",
        "http://localhost:3000/pricing",
        "http://localhost:3000/support"
      ]
    }
  }
}
```

This means instead of using the ENV var interpolation, I can switch to making a `lighthouse-ci.json` file ahead of time in the CI process