### PR TITLE
Remove warning for using static_dist_dir with urls

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -55,13 +55,6 @@ exports.getInput = function getInputArgs() {
     process.exit(1)
   }
 
-  // Warn if specifying both
-  if (urls.length > 0 && staticDistDir) {
-    core.warning(
-      `Setting both 'url' and 'static_dist_dir' will ignore urls in 'url' since 'static_dist_dir' has higher priority`
-    )
-  }
-
   return {
     // collect
     urls,


### PR DESCRIPTION
This PR removes the warning around using urls with a static dist directory. Support for this was added to lighthouse-ci in November 2019: https://github.com/GoogleChrome/lighthouse-ci/commit/93b674203a39520d40f6c985048d83d2ed46a2b8.

I set this up for my personal blog which uses Gatsby.js and [ran into this warning](https://github.com/gregjopa/gregjopa.github.io/actions/runs/72982452) even though everything's working fine:

<img width="1386" alt="Screen Shot 2020-04-07 at 3 11 26 PM" src="https://user-images.githubusercontent.com/534034/78715277-cb7b0300-78e2-11ea-9ae4-01de35718e6d.png">

It seems like this warning is unnecessary now.

Also thanks for this awesome project @alekseykulikov and Google Team 💯 It's amazing that this is all free to use. 