### PR TITLE
Update emoji in setFailedAnnotations

### DIFF
--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -25,7 +25,7 @@ exports.setFailedAnnotations = async function setFailedAnnotations(resultsPath) 
   Object.entries(assertionsByUrl).forEach(([url, assertions]) => {
     const link = linksByUrl[url]
     const assertionsText = assertions.map(a => {
-      const emoji = a.level === 'error' ? '🔴' : '🟡'
+      const emoji = a.level === 'error' ? '❌' : '⚠️'
       return (
         `${emoji} \`${a.auditId}.${a.auditProperty}\` ${a.level === 'error' ? 'failure' : 'warning'} for \`${
           a.name


### PR DESCRIPTION
I'm not sure what the `'🟡'` glyph is, but it renders as a box on my machine.

I was just going to file that as a bug, but I figure why not just adopt the X and warning sign that are used right in the comment above. :)

Open to changing them, but just wanted 2 clear icons for these states.