### PR TITLE
fix case when a.auditProperty is undefined

### DIFF
--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -27,9 +27,8 @@ exports.setFailedAnnotations = async function setFailedAnnotations(resultsPath) 
     const assertionsText = assertions.map(a => {
       const emoji = a.level === 'error' ? '🔴' : '🟡'
       return (
-        `${emoji} \`${a.auditId}.${a.auditProperty}\` ${a.level === 'error' ? 'failure' : 'warning'} for \`${
-          a.name
-        }\` assertion` +
+        `${emoji} \`${a.auditId}${a.auditProperty ? '.' + a.auditProperty : ''}\` `+
+        `${a.level === 'error' ? 'failure' : 'warning'} for \`${a.name}\` assertion` +
         `${a.auditTitle ? ` (${a.auditTitle}: ${a.auditDocumentationLink})` : ''}\n` +
         `Expected ${a.operator} ${a.expected}, but found ${a.actual}`
       )


### PR DESCRIPTION
Ran into this on a recent run: https://github.com/ChromeDevTools/debugger-protocol-viewer/runs/575487920

![image](https://user-images.githubusercontent.com/39191/78949329-09615e00-7a80-11ea-8c99-14d513212b4b.png)

loooking at https://github.com/GoogleChrome/lighthouse-ci/blob/6329be032572dd236da4eb7b721eb56d82441efc/packages/utils/test/assertions.test.js i see a buncha cases where there's an auditId but no auditProperty

so just tweaking the string construction