### PR TITLE
Adding basic auth actions to actions.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ against each of them. More details on this process are in the [Lighthouse CI doc
 
 </details>
 
-<details>  
+<details>
   <summary>Integrate Lighthouse CI with Netlify</summary><br>
 
 It waits for Netlify to finish building a preview and then uses a built version to check performance.
@@ -503,6 +503,18 @@ serverToken: ${{ secrets.LHCI_SERVER_TOKEN }}
 ```
 
 > **Note**: Use [Github secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) to keep your token hidden!
+
+
+#### `basicAuthUsername` `basicAuthPassword`
+
+Lighthouse servers can be protected with basic authentication [LHCI server basic authentication](https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/server.md#basic-authentication) by specifying both `basicAuthUsername` and `basicAuthPassword` will authenticate the upload.
+
+```yml
+basicAuthUsername: ${{ secrets.LHCI_SERVER_BASIC_AUTH_USERNAME }}
+basicAuthPassword: ${{ secrets.LHCI_SERVER_BASIC_AUTH_PASSWORD }}
+```
+
+> **Note**: Use [Github secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) to keep your username and password hidden!
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Address of a LHCI server'
   serverToken:
     description: 'API token to push to LHCI server'
+  basicAuthUsername:
+    description: 'Basic auth username for LHCI server'
+  basicAuthPassword:
+    description: 'Basic auth password for LHCI server'
 outputs:
   resultsPath:
     description: 'Path to the folder with LHCI results'

--- a/src/index.js
+++ b/src/index.js
@@ -78,13 +78,15 @@ async function main() {
           `--token=${input.serverToken}`,
           '--ignoreDuplicateBuildFailure' // ignore failure on the same commit rerun
         )
-      } else if (input.basicAuthPassword) {
+      } else if (input.temporaryPublicStorage) {
+        uploadParams.push('--target=temporary-public-storage')
+      }
+
+      if(input.basicAuthPassword) {
         uploadParams.push(
           `--basicAuth.username=${input.basicAuthUsername}`,
           `--basicAuth.password=${input.basicAuthPassword}`,
         )
-      } else if (input.temporaryPublicStorage) {
-        uploadParams.push('--target=temporary-public-storage')
       }
 
       const uploadStatus = runChildCommand('upload', uploadParams)


### PR DESCRIPTION
This PR make basic auth work if you have both `serverToken` and `basicAuth`  LHCI variables. 

Documentation [rendered](https://github.com/treosh/lighthouse-ci-action/blob/f588fd36ec97d9bde80cc8e8b31786ffc7824f0b/README.md#basicauthusername-basicauthpassword)