### PR TITLE
Correct url included in failed assertions

### DIFF
--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -37,7 +37,7 @@ exports.setAnnotations = async function setAnnotations(resultsPath) {
       return (
         `${emoji} \`${a.auditId}${a.auditProperty ? '.' + a.auditProperty : ''}\` ` +
         `${a.level === 'error' ? 'failure' : 'warning'} for \`${a.name}\` assertion` +
-        `${a.auditTitle ? ` (${a.auditTitle}: ${a.auditDocumentationLink})` : ''}\n` +
+        `${a.auditTitle ? ` (${a.auditTitle}: ${a.auditDocumentationLink} )` : ''}\n` +
         `Expected ${a.operator} ${a.expected}, but found ${a.actual}`
       )
     })


### PR DESCRIPTION
While using your great action I noticed that the failed assertions included a link to help pages, but the closing bracket was 'included' in the href in the console output, which means after you click it you get redirected to a wrong url:

![image](https://user-images.githubusercontent.com/11733084/94275680-88235800-ff47-11ea-8f40-d6bf1615f406.png)

There might be a very clean way to improve this but I just added a space which also works :-)