### PR TITLE
Hi,

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: 'Path to a LHCI lighthouserc.json file'
   uploadArtifacts:
     description: 'Opt-out of saving Lighthouse results as an action artifacts'
+  artifactName:
+    description: 'Name of the artifact group if using uploadArtifacts. default: lighthouse-results'
+    default: lighthouse-results
   temporaryPublicStorage:
     descripton: 'Opt-in to saving Lighthouse results to temporary public storage'
   runs:

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ async function main() {
   if (input.serverToken || input.temporaryPublicStorage || input.uploadArtifacts) {
     // upload artifacts as soon as collected
     if (input.uploadArtifacts) {
-      await uploadArtifacts(resultsPath)
+      await uploadArtifacts(resultsPath, input.artifactName)
     }
 
     if (input.serverToken || input.temporaryPublicStorage) {

--- a/src/utils/artifacts.js
+++ b/src/utils/artifacts.js
@@ -3,9 +3,8 @@ const fs = require('fs').promises
 const { join } = require('path')
 
 /** @param {string} resultsPath */
-exports.uploadArtifacts = async function uploadArtifacts(resultsPath) {
+exports.uploadArtifacts = async function uploadArtifacts(resultsPath, artifactName='lighthouse-results') {
   const artifactClient = artifact.create()
-  const artifactName = 'lighthouse-results'
   const fileNames = await fs.readdir(resultsPath)
   const files = fileNames.map((fileName) => join(resultsPath, fileName))
   return artifactClient.uploadArtifact(artifactName, files, resultsPath, { continueOnError: true })


### PR DESCRIPTION
Thanks for this useful action !

Looks like when we run two scans in parallel, this `lighthouse-results` folder is shared. Could be useful to be able to direct the artifacts output to different folders.