### PR TITLE
Update README.md to refer to Lighthouse v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is built in collaboration between Lighthouse Team, Treo (web performance moni
 
 **Features**:
 
-- ✅ Audit URLs using Lighthouse v8
+- ✅ Audit URLs using Lighthouse v9
 - 🎯 Test performance with Lighthouse CI assertions or performance budgets
 - 😻 See failed results in the action interface
 - 💾 Upload results to a private LHCI server, Temporary Public Storage, or as artifacts


### PR DESCRIPTION
Changing "Audit URLs using Lighthouse v8" to read "Audit URLs using Lighthouse v9"