### PR TITLE
Define Manifest as an output on action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,8 @@ outputs:
     description: 'Links to compare/result UI for each URL (content of links.json)'
   assertionResults:
     description: 'Assertion results (content of assertion-results.json)'
+  manifest:
+    description: 'Manifest results (content of manifest.json)'
 runs:
   using: 'node16'
   main: 'src/index.js'


### PR DESCRIPTION
When linting Github Actions with tools such as [actionlint](https://github.com/rhysd/actionlint), there are issues due to `manifest` not being defined as an output.

Should be an easy win.