### PR TITLE
updates Netlify example (Node v12 no longer required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,16 +283,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-      - name: Install & Build
-        run: |
-          yarn install
-          yarn build
       - name: Wait for the Netlify Preview
-        uses: jakepartusch/wait-for-netlify-action@v1
+        uses: jakepartusch/wait-for-netlify-action@v1.4
         id: netlify
         with:
           site_name: 'gallant-panini-bc8593'


### PR DESCRIPTION
jakepartusch/wait-for-netlify-action@v1.4 has been updated to [support Node v16](https://github.com/JakePartusch/wait-for-netlify-action/pull/26/files).

Working example: https://github.com/simpixelated/simpixelated.com/pull/144

Note: Using Node at v12 with the latest updates actually causes [this error](https://schalkneethling.com/posts/unexpected-token-syntax-error-lhci-cli).