### PR TITLE
Consider input from urls instead of config file when input exists

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -52,7 +52,7 @@ exports.getInput = function getInputArgs() {
   }
 
   // Get and interpolate URLs
-  urls = urls || interpolateProcessIntoUrls(getList('urls'))
+  urls = interpolateProcessIntoUrls(getList('urls')) || urls
 
   // Make sure we have either urls or a static-dist-dir
   if (!urls && !staticDistDir) {


### PR DESCRIPTION
What?
- Consider input from `urls` instead of config file when input exists

Why?
- To ensure a pattern where action inputs take priority over the configuration file