### PR TITLE
Filter for failed assertion results

### DIFF
--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -24,9 +24,10 @@ Expected <= 0, but found 1
 exports.setAnnotations = async function setAnnotations(resultsPath) {
   const links = await getLinks(resultsPath)
   const assertionResults = await getAssertionResults(resultsPath)
-  if (!assertionResults) return
+  const failedAssertions = assertionResults?.filter((a) => !a.passed)
+  if (!failedAssertions) return
 
-  const assertionResultsByUrl = mapValues(groupBy(assertionResults, 'url'), (assertions) => {
+  const assertionResultsByUrl = mapValues(groupBy(failedAssertions, 'url'), (assertions) => {
     return orderBy(assertions, (a) => (a.level === 'error' ? 0 : 1) + a.auditId)
   })
 


### PR DESCRIPTION
Filter failed assertion results in case `includePassedAssertions` flag is used. Fixes #130 