### PR TITLE
allow `staticDistDir` and `urls` combined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,9 @@ async function main() {
 
   if (input.staticDistDir) {
     collectArgs.push(`--static-dist-dir=${input.staticDistDir}`)
-  } else if (input.urls) {
+  }
+
+  if (input.urls) {
     for (const url of input.urls) {
       collectArgs.push(`--url=${url}`)
     }


### PR DESCRIPTION
As [documented](https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/configuration.md#url), `staticDistDir` and `url` can be used together and are not exclusive:

> **When used with `staticDistDir`:**
> 
> - Automatic detection of URLs based on HTML files on disk will be disabled.
> - URLs will have their port replaced with the port of the local server that Lighthouse CI starts for you. This allows you to write URLs as `http://localhost/my-static-page.html` without worrying about the chosen temporary port.
> 
> **When used without `staticDistDir`:**
> 
> - URLs will be used as-is without modification.